### PR TITLE
[8.0] l10n_es_aeat_sii: facturas emitidas rectificativas base imponible negativa

### DIFF
--- a/l10n_es_aeat_sii/README.rst
+++ b/l10n_es_aeat_sii/README.rst
@@ -93,6 +93,7 @@ Contributors
 * Omar Castiñeira - Comunitea S.L. <omar@comunitea.com>
 * Ismael Calvo - Factor Libre S.L.
 * Alberto Martín Cortada - Guadaltehch
+* Luis J. Salvatierra <ljsalvatierra@binovo.es>
 
 
 Maintainer

--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -7,7 +7,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.1.2.2",
+    "version": "8.0.1.2.3",
     "category": "Accounting & Finance",
     "website": "https://www.acysos.com",
     "author": "Acysos S.L.",


### PR DESCRIPTION
A raíz de la incidencia #22. Se cambia el signo siempre y cuando sea una factura rectificativa y por diferencias según lo comentado con el departamento de Hacienda y Finanzas de Gipuzkoa.