### PR TITLE
[8.0] l10n_es_aeat_sii: País extranjero con posición fiscal distinta a Régimen intracomunitario

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -7,7 +7,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.1.2.3",
+    "version": "8.0.1.2.4",
     "category": "Accounting & Finance",
     "website": "https://www.acysos.com",
     "author": "Acysos S.L.",

--- a/l10n_es_aeat_sii/i18n/es.po
+++ b/l10n_es_aeat_sii/i18n/es.po
@@ -7,8 +7,8 @@ msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-01-25 18:25+0000\n"
-"PO-Revision-Date: 2018-01-25 19:28+0100\n"
-"Last-Translator: Ignacio Ibeas - Acysos S.L. <ignacio@acysos.com>\n"
+"PO-Revision-Date: 2018-11-15 19:28+0100\n"
+"Last-Translator: Binovo IT Human Project S.L. <ljsalvatierra@binovo.es>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -992,3 +992,15 @@ msgstr "Debe seleccionar que plan contable utiliza esta compañía"
 #: view:l10n.es.aeat.sii.password:l10n_es_aeat_sii.l10n_es_sii_password_wizard_view
 msgid "or"
 msgstr "o"
+
+#. module: l10n_es_aeat_sii
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1006
+#, python-format
+msgid "Partner has no country or it is invalid."
+msgstr "La empresa no tiene país establecido o es inválido."
+
+#. module: l10n_es_aeat_sii
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1008
+#, python-format
+msgid "Invoice fiscal position is not set."
+msgstr "La factura no tiene establecida la posición fiscal."

--- a/l10n_es_aeat_sii/i18n/l10n_es_aeat_sii.pot
+++ b/l10n_es_aeat_sii/i18n/l10n_es_aeat_sii.pot
@@ -7,8 +7,8 @@ msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-01-25 18:25+0000\n"
-"PO-Revision-Date: 2018-01-25 18:25+0000\n"
-"Last-Translator: <>\n"
+"PO-Revision-Date: 2018-11-15 18:25+0000\n"
+"Last-Translator: Binovo IT Human Project S.L. <ljsalvatierra@binovo.es>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1014,5 +1014,17 @@ msgstr ""
 #. module: l10n_es_aeat_sii
 #: view:l10n.es.aeat.sii.password:l10n_es_aeat_sii.l10n_es_sii_password_wizard_view
 msgid "or"
+msgstr ""
+
+#. module: l10n_es_aeat_sii
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1006
+#, python-format
+msgid "Partner has no country or it is invalid."
+msgstr ""
+
+#. module: l10n_es_aeat_sii
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1008
+#, python-format
+msgid "Invoice fiscal position is not set."
 msgstr ""
 

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -849,6 +849,9 @@ class AccountInvoice(models.Model):
                 self.env['aeat.sii.result'].create_result(
                     invoice, False, 'normal', fault, 'account.invoice')
                 self.sii_send_error = fault
+            finally:
+                # avoid transaction rollback
+                self._cr.commit()
 
     @api.multi
     def send_recc_payment_registry(self, move):

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1021,6 +1021,7 @@ class AccountInvoice(models.Model):
                     "ID": vat
                 }
             }
+            dic_ret = self._fix_country_code(dic_ret)
         _logger.info(dic_ret)
         return dic_ret
 


### PR DESCRIPTION
Debido a una comunicación por parte de la Hacienda Guipuzcoana a un cliente, hemos tenido que realizar una pequeña modificación para poder seguir enviando información sobre un emisor extranjero con posición fiscal distinta a Régimen intracomunitario.

Entendemos que es una problemática especial y extraña, aún así, creémos pertinente dejar disponible a la comunidad dichos cambios.

Un saludo.