### PR TITLE
10.0 fix l10n es aeat sii pos

### DIFF
--- a/l10n_es_aeat_sii_pos/__manifest__.py
+++ b/l10n_es_aeat_sii_pos/__manifest__.py
@@ -17,7 +17,7 @@
     "depends": [
         "l10n_es",
         "l10n_es_aeat_sii",
-#         "l10n_es_pos"
+        "l10n_es_pos"
     ],
     "data": [
         'views/point_of_sale_view.xml'


### PR DESCRIPTION
Se arreglan y modifican alguna cosas:
- Se hereda del módulo l10n_es_pos, para enviar como secuencia de factura la secuencia de factura simplificada y no el número de pedido
- Se añade el field sii_cancel para que no de el error "'pos.order' object has no attribute 'sii_cancel'"
- Se modifica la key = "01" para que mande la de la posición fiscal (siempre que esté establecida)
- Arreglado error en la llamada al método compute_all
- Se envían los impuestos después de pasar por la posición fiscal

Con estos cambios, se facilita 100% la herencia para el módulo l10n_es_aeat_sii_pos_igic