### PR TITLE
[8.0] l10n_es_aeat_sii: evitar rollback transacción al enviar múltiples facturas

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -7,7 +7,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.1.2.3",
+    "version": "8.0.1.2.4",
     "category": "Accounting & Finance",
     "website": "https://www.acysos.com",
     "author": "Acysos S.L.",

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -849,6 +849,9 @@ class AccountInvoice(models.Model):
                 self.env['aeat.sii.result'].create_result(
                     invoice, False, 'normal', fault, 'account.invoice')
                 self.sii_send_error = fault
+            finally:
+                # avoid transaction rollback
+                self._cr.commit()
 
     @api.multi
     def send_recc_payment_registry(self, move):


### PR DESCRIPTION
En caso de realizar un envío de múltiples facturas, donde varias han sido enviadas correctamente y en una posterior ocurre algún error fuera del alcance *try..except*, no se guarda correctamente aquellas enviadas de manera correcta, por ejemplo, seguirían marcadas como no enviadas y al intentar realizar de nuevo el envío aparecería un error de factura duplicada.