### PR TITLE
[10.0] FIX -  l10n_es_aeat_sii_simplified

### DIFF
--- a/l10n_es_aeat_sii_simplified/models/account_invoice.py
+++ b/l10n_es_aeat_sii_simplified/models/account_invoice.py
@@ -25,7 +25,7 @@ class AccountInvoice(models.Model):
             if self.amount_total > self.company_id.simplified_limit:
                 raise UserError(_(
                     "The total of the invoice %s is more that %f €") % (
-                        self.invoice_number, self.company_id.simplified_limit))
+                        self.number, self.company_id.simplified_limit))
             if self.amount_total < 0 or self.type in ['in_refund', 'out_refund']:
                 tipo_factura = 'R5'
             else:


### PR DESCRIPTION
Se modifica el archivo /models/account_invoice.py

En caso de que se supere el límite de facturación en una factura simplificada, se produce un error porque el modelo "account.invoice" no tiene el campo "invoice_number".

El número de factura se encuentra en el campo "number"

Se han revisado las dependencias y no aparece ninguna declaración del campo "invoice_number" para el modelo"account.invoice". Solo aparece una declaración de un campo 
 "invoice_number" y es en el modelo "aeat.check.sii.result".